### PR TITLE
Ensure we close any existing ssh connection in testGerritConnection

### DIFF
--- a/src/main/java/com/houghtonassociates/bamboo/plugins/dao/GerritService.java
+++ b/src/main/java/com/houghtonassociates/bamboo/plugins/dao/GerritService.java
@@ -142,6 +142,9 @@ public class GerritService {
                 SshConnectionFactory.getConnection(gc.getHost(), gc.getPort(),
                     gc.getAuth());
         } catch (IOException e) {
+            if(sshConnection != null) {
+              sshConnection.disconnect();
+            }
             throw new RepositoryException(
                 "Failed to establish connection to Gerrit!");
         }


### PR DESCRIPTION
We saw an increase in the number of ssh connection from the Bamboo server to our Gerrit server.
